### PR TITLE
feat: add confirmation dialog on clear history

### DIFF
--- a/REPO_SUMMARY.md
+++ b/REPO_SUMMARY.md
@@ -1,0 +1,120 @@
+# Repository Summary: qr-scanner
+
+## YAML (Human-Readable)
+
+```yaml
+name: qr-scanner
+description: QR code scanner webapp with camera access and scan history
+type: web-application
+language: TypeScript/React
+framework: Vite + React 19
+
+tech_stack:
+  frontend:
+    - React 19.2.4
+    - React DOM 19.2.4
+    - Tailwind CSS 4.1.11
+    - @yudiel/react-qr-scanner 2.5.1
+  build:
+    - Vite 8.0.0
+    - @vitejs/plugin-react 6.0.0
+    - @tailwindcss/vite 4.1.11
+  dev:
+    - TypeScript types
+    - Autoprefixer
+    - PostCSS
+
+entry_points:
+  - src/main.tsx         # React entry point
+  - src/App.tsx          # Main app component with scanner UI
+
+config_files:
+  - vite.config.ts       # Vite config (base: /qr-scanner/, output: docs/)
+  - package.json         # Dependencies and scripts
+  - manifest.json        # PWA manifest
+  - index.html           # HTML template
+
+modules:
+  App:
+    file: src/App.tsx
+    purpose: Main scanner component with camera, history, and actions
+    functions:
+      - handleScan: Process detected QR codes
+      - handleError: Camera error handling
+      - clearHistory: Clear localStorage history
+      - copyToClipboard: Copy scanned data
+      - openUrl: Open valid URLs
+      - toggleScanner: Pause/resume camera
+
+dependencies:
+  external:
+    - @yudiel/react-qr-scanner (QR scanning)
+    - react, react-dom (UI framework)
+    - tailwindcss (styling)
+
+side_effects:
+  - localStorage: Persists scan history (key: qrScanHistory, max: 50 items)
+  - navigator.clipboard: Copy to clipboard
+  - window.open: Open URLs in new tab
+  - Camera API: Device camera access for scanning
+
+deployment:
+  ci: GitHub Actions (.github/workflows/deploy.yml)
+  host: GitHub Pages
+  output: docs/ folder
+  base_path: /qr-scanner/
+
+tests: none
+linting: none
+```
+
+## JSON (AI-Indexable)
+
+```json
+{
+  "name": "qr-scanner",
+  "type": "web-application",
+  "language": "typescript",
+  "framework": "react",
+  "build": "vite",
+  "entry_points": [
+    "src/main.tsx",
+    "src/App.tsx"
+  ],
+  "modules": {
+    "App": {
+      "file": "src/App.tsx",
+      "exports": ["default"],
+      "functions": [
+        {"name": "handleScan", "params": ["detectedCodes"], "sideEffects": ["localStorage"]},
+        {"name": "handleError", "params": ["err"]},
+        {"name": "clearHistory", "sideEffects": ["localStorage"]},
+        {"name": "copyToClipboard", "sideEffects": ["clipboard API"]},
+        {"name": "openUrl", "sideEffects": ["window.open"]},
+        {"name": "toggleScanner", "params": []}
+      ],
+      "state": ["scannedData", "error", "paused", "history", "notification"]
+    }
+  },
+  "config": {
+    "vite": {"base": "/qr-scanner/", "outDir": "docs"},
+    "pwa": {"name": "Code Scanner", "themeColor": "#3498db"}
+  },
+  "dependencies": {
+    "@yudiel/react-qr-scanner": "^2.5.1",
+    "react": "^19.2.4",
+    "tailwindcss": "^4.1.11"
+  },
+  "storage": {
+    "localStorage": {"key": "qrScanHistory", "maxItems": 50}
+  },
+  "deployment": {
+    "ci": "GitHub Actions",
+    "host": "GitHub Pages"
+  }
+}
+```
+
+---
+
+**Summary:** A lightweight React QR scanner PWA that uses the device camera to scan codes, stores history in localStorage, and can open valid URLs. Built with Vite + Tailwind CSS, deploys to GitHub Pages. No tests or linting configured.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -43,6 +43,16 @@ export default function App() {
     return () => window.clearTimeout(timer);
   }, [notification]);
 
+  useEffect(() => {
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setShowClearConfirm(false);
+    };
+    if (showClearConfirm) {
+      document.addEventListener("keydown", handleEscape);
+      return () => document.removeEventListener("keydown", handleEscape);
+    }
+  }, [showClearConfirm]);
+
   const persistHistory = (nextHistory: HistoryItem[]) => {
     setHistory(nextHistory);
     localStorage.setItem(STORAGE_KEY, JSON.stringify(nextHistory));
@@ -297,9 +307,14 @@ export default function App() {
         </section>
 
         {showClearConfirm && (
-          <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
+          <div
+            className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="clear-history-title"
+          >
             <div className="w-full max-w-sm rounded-2xl bg-white p-6 shadow-xl">
-              <h3 className="text-lg font-semibold text-slate-800">
+              <h3 id="clear-history-title" className="text-lg font-semibold text-slate-800">
                 Clear scan history?
               </h3>
               <p className="mt-2 text-sm text-slate-600">

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,6 +22,7 @@ export default function App() {
   const [paused, setPaused] = useState(true);
   const [history, setHistory] = useState<HistoryItem[]>([]);
   const [notification, setNotification] = useState("");
+  const [showClearConfirm, setShowClearConfirm] = useState(false);
 
   useEffect(() => {
     const saved = localStorage.getItem(STORAGE_KEY);
@@ -82,6 +83,11 @@ export default function App() {
     setHistory([]);
     setNotification("History cleared");
     localStorage.removeItem(STORAGE_KEY);
+  };
+
+  const confirmClear = () => {
+    clearHistory();
+    setShowClearConfirm(false);
   };
 
   const copyToClipboard = async () => {
@@ -217,7 +223,7 @@ export default function App() {
                 Scan again
               </button>
               <button
-                onClick={clearHistory}
+                onClick={() => setShowClearConfirm(true)}
                 className="rounded-lg bg-red-500 px-2.5 py-1.5 text-xs font-medium text-white hover:bg-red-600"
               >
                 Clear history
@@ -289,6 +295,34 @@ export default function App() {
             </div>
           )}
         </section>
+
+        {showClearConfirm && (
+          <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
+            <div className="w-full max-w-sm rounded-2xl bg-white p-6 shadow-xl">
+              <h3 className="text-lg font-semibold text-slate-800">
+                Clear scan history?
+              </h3>
+              <p className="mt-2 text-sm text-slate-600">
+                This will delete {history.length} saved scan(s). This action
+                cannot be undone.
+              </p>
+              <div className="mt-5 flex gap-3">
+                <button
+                  onClick={() => setShowClearConfirm(false)}
+                  className="flex-1 rounded-lg border border-slate-200 bg-slate-50 px-4 py-2 text-sm font-medium text-slate-700 hover:bg-slate-100"
+                >
+                  Cancel
+                </button>
+                <button
+                  onClick={confirmClear}
+                  className="flex-1 rounded-lg bg-red-500 px-4 py-2 text-sm font-medium text-white hover:bg-red-600"
+                >
+                  Clear All
+                </button>
+              </div>
+            </div>
+          </div>
+        )}
       </div>
     </main>
   );


### PR DESCRIPTION
## Summary
- Added confirmation modal before clearing scan history
- Modal displays accurate count of items to be deleted
- Cancel button closes modal without action
- Clear All button clears history and closes modal

Closes #3